### PR TITLE
Load MongoDB URL from the .env file

### DIFF
--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -2,10 +2,11 @@ import asyncio
 import discord
 import pymongo
 import random
+import os
 from pymongo import MongoClient
 from discord.ext import commands
 
-cluster = MongoClient("https://bit.ly/dpyjslol")
+cluster = MongoClient(os.environ["MONGODB_URL"])
 
 
 class EconomyCog(commands.Cog):

--- a/cogs/logging.py
+++ b/cogs/logging.py
@@ -3,6 +3,7 @@ import pymongo
 import typing
 import io
 import datetime
+import os
 from io import BytesIO
 from typing import Optional
 from discord import TextChannel
@@ -10,7 +11,7 @@ from pymongo import MongoClient
 from discord.ext import commands
 from discord.ext.commands import has_permissions, MissingPermissions
 
-cluster = MongoClient("uh really, why you look here: https://bit.ly/dpyjslol")
+cluster = MongoClient(os.environ["MONGODB_URL"])
 
 
 class LoggingCog(commands.Cog):


### PR DESCRIPTION
As we noticed on previous commits, the MongoDB URL was leaked. This will fix that forever.