### PR TITLE
Load the MongoDB from the .env file to avoid URL leaks.

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -26,7 +26,7 @@ def get_prefix(bot, message):
     prefixes = ['w/', 'world ']
     return commands.when_mentioned_or(*prefixes)(bot, message)
 
-bot = commands.Bot(command_prefix=get_prefix, description='Discord Bot Made For All', case_insensitive=True, intents=discord.Intents.all())
+bot = commands.Bot(command_prefix=get_prefix, description='Discord Bot Made For All', case_insensitive=True)
 bot.remove_command("help")
 
 initial_extensions = ['cogs.owner', 'cogs.ping', 'cogs.help',

--- a/bot.py
+++ b/bot.py
@@ -26,7 +26,7 @@ def get_prefix(bot, message):
     prefixes = ['w/', 'world ']
     return commands.when_mentioned_or(*prefixes)(bot, message)
 
-bot = commands.Bot(command_prefix=get_prefix, description='Discord Bot Made For All', case_insensitive=True)
+bot = commands.Bot(command_prefix=get_prefix, description='Discord Bot Made For All', case_insensitive=True, intents=discord.Intents.all())
 bot.remove_command("help")
 
 initial_extensions = ['cogs.owner', 'cogs.ping', 'cogs.help',

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -2,10 +2,11 @@ import asyncio
 import discord
 import pymongo
 import random
+import os
 from pymongo import MongoClient
 from discord.ext import commands
 
-cluster = MongoClient("https://bit.ly/dpyjslol")
+cluster = MongoClient(os.environ["MONGODB_URL"])
 
 
 class EconomyCog(commands.Cog):

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -5,6 +5,9 @@ import random
 import os
 from pymongo import MongoClient
 from discord.ext import commands
+from dotenv import load_dotenv
+
+load_dotenv()
 
 cluster = MongoClient(os.environ["MONGODB_URL"])
 

--- a/cogs/logging.py
+++ b/cogs/logging.py
@@ -10,6 +10,9 @@ from discord import TextChannel
 from pymongo import MongoClient
 from discord.ext import commands
 from discord.ext.commands import has_permissions, MissingPermissions
+from dotenv import load_dotenv
+
+load_dotenv()
 
 cluster = MongoClient(os.environ["MONGODB_URL"])
 

--- a/cogs/logging.py
+++ b/cogs/logging.py
@@ -3,6 +3,7 @@ import pymongo
 import typing
 import io
 import datetime
+import os
 from io import BytesIO
 from typing import Optional
 from discord import TextChannel
@@ -10,7 +11,7 @@ from pymongo import MongoClient
 from discord.ext import commands
 from discord.ext.commands import has_permissions, MissingPermissions
 
-cluster = MongoClient("uh really, why you look here: https://bit.ly/dpyjslol")
+cluster = MongoClient(os.environ["MONGODB_URL"])
 
 
 class LoggingCog(commands.Cog):


### PR DESCRIPTION
Previously, we saw the MongoDB URL get leaked multiple times. This will be fixed forever. Just add a `MONGODB_URL` key to the `.env` file.